### PR TITLE
Added update scripts for Linux and Windows

### DIFF
--- a/Update_VISOR_Linux.sh
+++ b/Update_VISOR_Linux.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+git checkout -f main
+git reset --hard origin/main
+git pull origin main
+python./tools/download_models.py
+python./tools/update_rope.py
+
+echo
+echo --------Update completed--------
+echo

--- a/Update_VISOR_Linux.sh
+++ b/Update_VISOR_Linux.sh
@@ -3,8 +3,6 @@
 git checkout -f main
 git reset --hard origin/main
 git pull origin main
-python./tools/download_models.py
-python./tools/update_rope.py
 
 echo
 echo --------Update completed--------

--- a/Update_VISOR_Win.bat
+++ b/Update_VISOR_Win.bat
@@ -1,0 +1,9 @@
+git checkout -f main
+git reset --hard origin/main
+git pull origin main
+
+echo.
+echo --------Update completed--------
+echo.
+
+pause


### PR DESCRIPTION
This pull request adds two new scripts to simplify updating the VISOR project on both Linux and Windows platforms.

The Update_VISOR_Linux.sh script is designed for Linux users and can be run from the terminal to update the project to the latest version.

The Update_VISOR_Win.bat script is designed for Windows users and can be run by double-clicking the file to update the project to the latest version.

Both scripts use Git to fetch the latest changes from the remote repository and update the local project accordingly.

These scripts aim to make it easier for users to keep their local copies of the VISOR project up-to-date, regardless of their operating system.